### PR TITLE
simple-upnpd.skeleton.xml file for raspberrypi2

### DIFF
--- a/meta-ve-software/recipes-networking/simple-upnpd/files/raspberrypi2/simple-upnpd.skeleton.xml
+++ b/meta-ve-software/recipes-networking/simple-upnpd/files/raspberrypi2/simple-upnpd.skeleton.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root xmlns="urn:schemas-upnp-org:device-1-0">
+  <specVersion>
+    <major>1</major>
+    <minor>0</minor>
+  </specVersion>
+
+  <device>
+    <deviceType>urn:schemas-upnp-org:device:Basic:1</deviceType>
+      <friendlyName>RaspberryPi</friendlyName>
+      <manufacturer>Victron Energy</manufacturer>
+      <manufacturerURL>http://www.victronenergy.com</manufacturerURL>
+      <modelName>CCGX</modelName>
+      <modelNumber>1.0</modelNumber>
+      <modelURL>http://www.victronenergy.com/live/ccgx:start</modelURL>
+      <UDN>uuid:com.victronenergy.ccgx</UDN>
+    </device>
+</root>


### PR DESCRIPTION
This minor allows simple-upnpd to build on a raspberrypi2.
