### PR TITLE
Harden SSH configuration

### DIFF
--- a/meta-venus/recipes-connectivity/openssh/sshd_config
+++ b/meta-venus/recipes-connectivity/openssh/sshd_config
@@ -117,3 +117,9 @@ Subsystem	sftp	/usr/libexec/sftp-server
 #	X11Forwarding no
 #	AllowTcpForwarding no
 #	ForceCommand cvs server
+# Prefer Elliptic curves (don't allow any NIST curves) - allow custom 2048 bit DH group
+KexAlgorithms curve25519-sha256@libssh.org,diffie-hellman-group-exchange-sha256
+# Prefer ChaCha20/Poly1305 - GCM - fall back to less secure CTR mode ciphers
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+# Don't allow SHA1 and MD5,and keysizes < 128 bit
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,hmac-ripemd160-etm@openssh.com,umac-128-etm@openssh.com,hmac-sha2-512,hmac-sha2-256,hmac-ripemd160,umac-128@openssh.com


### PR DESCRIPTION
Note that while a reasonable amount of backwards compatibility is specified,
this might still cause issues with older SSH versions.
Further testing / minimal specifications are recommended, to prevent SSH
communication issues due to this hardened configuration.