### PR TITLE
add support for gridless.octo with a slightly different (different from bbb-venus) dts file.

### DIFF
--- a/meta-bsp/recipes-bsp/u-boot/u-boot-bbb/uEnv.txt
+++ b/meta-bsp/recipes-bsp/u-boot/u-boot-bbb/uEnv.txt
@@ -15,5 +15,5 @@ mmcargs=setenv bootargs console=${console} ${optargs} root=${mmcroot} rw rootfst
 loadfdt=load mmc ${bootpart} ${fdtaddr} ${bootdir}/${fdtfile}
 loadimage=load mmc ${bootpart} ${loadaddr} ${bootdir}/${bootfile}
 setroot=if test ${version} = 2; then setenv bootpart 1:3; setenv mmcroot /dev/mmcblk1p3; fi
-findfdt=if test $board_rev = SE0A; then setenv fdtfile bbe-venus.dtb; fi;
+findfdt=if test $board_rev = SE0A; then setenv fdtfile bbe-venus.dtb; fi; if test $board_rev = GOB1; then setenv fdtfile bbb-octo-venus.dtb; fi;
 uenvcmd=run setroot; run findfdt; if run loadfdt; then echo Loaded ${fdtfile}; if run loadimage; then run mmcargs; bootz ${loadaddr} - ${fdtaddr}; fi; fi;

--- a/meta-bsp/recipes-kernel/linux/linux-bbb/0004-add_gridless_octo_dts.patch
+++ b/meta-bsp/recipes-kernel/linux/linux-bbb/0004-add_gridless_octo_dts.patch
@@ -1,0 +1,39 @@
+diff --git a/arch/arm/boot/dts/bbb-octo-venus.dts b/arch/arm/boot/dts/bbb-octo-venus.dts
+new file mode 100644
+index 00000000..cb2fca37
+--- /dev/null
++++ b/arch/arm/boot/dts/bbb-octo-venus.dts
+@@ -0,0 +1,33 @@
++/dts-v1/;
++
++#include "am33xx.dtsi"
++#include "am335x-bone-common.dtsi"
++#include "bb-ve-cape.dtsi"
++
++/ {
++	model = "TI AM335x BeagleBone Black with victronenergy cape";
++	compatible = "ti,am335x-bone-black", "ti,am33xx";
++};
++
++&ldo3_reg {
++	regulator-min-microvolt = <1800000>;
++	regulator-max-microvolt = <1800000>;
++	regulator-always-on;
++};
++
++&mmc1 {
++	vmmc-supply = <&vmmcsd_fixed>;
++};
++
++&mmc2 {
++	vmmc-supply = <&vmmcsd_fixed>;
++	pinctrl-names = "default";
++	pinctrl-0 = <&emmc_pins>;
++	bus-width = <8>;
++	status = "okay";
++};
++
++&usb0 {
++	status = "okay";
++	dr_mode = "host";
++};

--- a/meta-bsp/recipes-kernel/linux/linux-bbb_4.1.39-bbb1.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-bbb_4.1.39-bbb1.bb
@@ -11,6 +11,7 @@ KERNEL_CONFIG_COMMAND = "make -C ${S} O=${B} ARCH=arm bbb_defconfig"
 KERNEL_DEVICETREE = " \
     am335x-boneblack.dtb \
     bbb-venus.dtb \
+    bbb-octo-venus.dtb \
     bbe-venus.dtb \
 "
 
@@ -31,4 +32,5 @@ SRC_URI += " \
 	file://0001-Bluetooth-btusb-fix-Realtek-suspend-resume.patch \
 	file://0002-Bluetooth-btusb-match-generic-class-code-in-interfac.patch \
 	file://0003-bbb_defconfig-enable-bluetooth.patch \
+	file://0004-add_gridless_octo_dts.patch \
 "

--- a/meta-venus/recipes-images/venus-install-sdcard.bb
+++ b/meta-venus/recipes-images/venus-install-sdcard.bb
@@ -12,7 +12,7 @@ DEPENDS += "\
 	parted-native \
 "
 
-DTB_beaglebone = "${KERNEL_IMAGETYPE}-bbb-venus.dtb ${KERNEL_IMAGETYPE}-bbe-venus.dtb"
+DTB_beaglebone = "${KERNEL_IMAGETYPE}-bbb-venus.dtb ${KERNEL_IMAGETYPE}-bbb-octo-venus.dtb ${KERNEL_IMAGETYPE}-bbe-venus.dtb"
 
 SCR = "fatload-initramfs.scr"
 SCR_beaglebone = "install-${MACHINE}.scr"


### PR DESCRIPTION
I tried to get all places for getting the new dtb created and copied to the /boot/ partition.
But im not sure where the link from /boot/devicetree-zImage-bbb-venus.dtb -> /boot/bbb-venus.dtb is created? Is this maybe done by openembedded itself?