### PR TITLE
correct SLCAN USB device name generation

### DIFF
--- a/meta-venus/recipes-connectivity/can-utils/files/can-set-rate
+++ b/meta-venus/recipes-connectivity/can-utils/files/can-set-rate
@@ -2,7 +2,7 @@
 
 dev=$1
 rate=$2
-tty=/dev/tty$dev
+tty=$(ps |grep slcand|grep $dev|sed 's/.*\/dev/\/dev/' |cut -d' ' -f0)
 
 test -e $tty && is_slcan=y
 


### PR DESCRIPTION
The can-set-rate script generates the device name for an SLCAN device incorrectly. It will try and look for a device called /dev/ttycanx whereas SLCAN devices appear as /dev/ttyUSBy. This change is a quick and dirty fix that works. A more elegant alternative may be possible.