### PR TITLE
Update start-node-red.sh

### DIFF
--- a/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
+++ b/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
@@ -15,6 +15,10 @@ if [ ! -d $NODE_RED ]; then
 	sed -i "s/a-secret-key/`openssl rand -hex 32`/g" "$NODE_RED/settings.js"
 fi
 
+if [ ! -d $DATA_MODULES ]; then
+	mkdir $DATA_MODULES
+fi
+
 if [ -d $VICTRON ]; then
 	rm -rf $VICTRON
 fi


### PR DESCRIPTION
If an `rm -rf /data/home/root/.node-red/` has been done in order to go back to factory defaults, the `touch` gives an error.  (`touch: /data/home/root/.node-red/node_modules/@victronenergy: No such file or directory`).  This fixes that.