### PR TITLE
Node-red: bugfix and feature enhancements

### DIFF
--- a/meta-venus/recipes-extended/node-red/node-red/settings.js
+++ b/meta-venus/recipes-extended/node-red/node-red/settings.js
@@ -118,9 +118,11 @@ module.exports = {
 
     // Securing Node-RED
     // -----------------
-    // To password protect the Node-RED editor and admin API, the following
+    // To password protect the Node-RED editor and admin API, the adminAuth
     // property can be used. See http://nodered.org/docs/security.html for details.
-    adminAuth: require("./user-authentication"),
+    // The /usr/lib/node_modules/node-red/user-authentication.js require
+    // uses the password from /data/conf/vncpassword.txt for authentication.
+    adminAuth: require("/usr/lib/node_modules/node-red/user-authentication.js"),
 
     // To password protect the node-defined HTTP endpoints (httpNodeRoot), or
     // the static content (httpStatic), the following properties can be used.

--- a/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
+++ b/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 exec 2>&1
-echo "*** Starting node-red ***"
+echo "*** Starting node-red script ***"
 
 NODE_RED="/data/home/root/.node-red"
 DATA_MODULES="$NODE_RED/node_modules"
@@ -20,11 +20,13 @@ if [ -d $VICTRON ]; then
 fi
 
 if [ ! -f $VICTRON ]; then
-    touch $VICTRON
+	touch $VICTRON
 fi
 
-if [ ! -d $DATA_MODULES/bcryptjs ]; then
-    (cd $NODE_RED; npm install bcryptjs; npm install debug)
-fi
+for MODULE in bcryptjs debug; do
+	if [ ! -d $DATA_MODULES/${MODULE} ]; then
+		(cd $NODE_RED; npm install ${MODULE})
+	fi
+done
 
-exec /usr/lib/node_modules/node-red/red.js
+exec /usr/lib/node_modules/node-red/red.js $@ --userDir ${NODE_RED}

--- a/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
+++ b/meta-venus/recipes-extended/node-red/node-red/start-node-red.sh
@@ -10,7 +10,6 @@ DEFAULTCONF="/usr/lib/node_modules/node-red/defaults"
 if [ ! -d $NODE_RED ]; then
 	mkdir $NODE_RED
 	mkdir $DATA_MODULES
-	cp "$DEFAULTCONF/user-authentication.js" "$NODE_RED"
 	cp "$DEFAULTCONF/settings.js" "$NODE_RED"
 	sed -i "s/a-secret-key/`openssl rand -hex 32`/g" "$NODE_RED/settings.js"
 fi
@@ -22,11 +21,5 @@ fi
 if [ ! -f $VICTRON ]; then
 	touch $VICTRON
 fi
-
-for MODULE in bcryptjs debug; do
-	if [ ! -d $DATA_MODULES/${MODULE} ]; then
-		(cd $NODE_RED; npm install ${MODULE})
-	fi
-done
 
 exec /usr/lib/node_modules/node-red/red.js $@ --userDir ${NODE_RED}

--- a/meta-venus/recipes-extended/node-red/node-red/user-authentication.js
+++ b/meta-venus/recipes-extended/node-red/node-red/user-authentication.js
@@ -57,7 +57,7 @@ function getPassword() {
     const data = String(fs.readFileSync('/data/conf/vncpassword.txt')).trim()
     return data.length > 0 ? data : null
   } catch (err) {
-    console.err(err)
+    console.error(err)
     return null
   }
 }

--- a/meta-venus/recipes-extended/node-red/node-red_1.3.2.bb
+++ b/meta-venus/recipes-extended/node-red/node-red_1.3.2.bb
@@ -37,7 +37,7 @@ do_install_append() {
 	# to the data partition on first boot.
 	install -d ${NPM_INSTALLDIR}/defaults
 	install -m 0755 ${WORKDIR}/settings.js ${NPM_INSTALLDIR}/defaults
-	install -m 0755 ${WORKDIR}/user-authentication.js ${NPM_INSTALLDIR}/defaults
+	install -m 0755 ${WORKDIR}/user-authentication.js ${NPM_INSTALLDIR}
 
 	# Symlinks
 	mkdir ${D}${bindir}


### PR DESCRIPTION
- Bugfix: Check for each installed module before (re)installing them. See https://community.victronenergy.com/questions/88827/node-red-dont-get-everytime-connected-notification.html for a case where this went wrong. 
- Be less verbose if node-red is used interactive. This allows the command `node-red` to be used on the same way as described on https://nodered.org/docs/user-guide/runtime/securing-node-red (`node-red admin hash-pw`)
- Accept parameters (eg `--safe`) to passthrough to the node-red javascript file.
- Prepare for moving node-red to other location on filesystem by adding the `--userDir` to the node-red call.