### PR TITLE
compile openjdk-8 for victron venus

### DIFF
--- a/meta-venus/conf/distro/venus.conf
+++ b/meta-venus/conf/distro/venus.conf
@@ -41,7 +41,8 @@ PREFERRED_VERSION_swupdate = "2016.10"
 # No idea what a good choice is here, this is from the meta-java its manpage
 # Possible provider: cacao-initial-native and jamvm-initial-native
 PREFERRED_PROVIDER_virtual/java-initial-native = "cacao-initial-native"
-PREFERRED_PROVIDER_virtual/java-native = "cacao-native"
+PREFERRED_PROVIDER_virtual/java-native = "jamvm-native"
+PREFERRED_PROVIDER_virtual/javac-native = "ecj-bootstrap-native"
 
 SWU_VERSION ?= "1"
 SWU ?= "venus-swu${@d.getVar('SWU_VERSION') > '1' and '-' + d.getVar('SWU_VERSION') or ''}"


### PR DESCRIPTION
- set jamvm as java-native.
- added ecj-bootrap-native for javac.
-> allows for openjdk-8 to be compiled properly.

These lines seemed to be a leftover or unused.
I managed to compile openjdk-8 for venus when using the recommended default: jamvm-native.
Tested with http://git.yoctoproject.org/cgit/cgit.cgi/meta-java zeus origin/zeus