### PR TITLE
Updates to Support RPI 5.10.y kernel

### DIFF
--- a/meta-bsp/conf/machine/include/rpi-base.inc
+++ b/meta-bsp/conf/machine/include/rpi-base.inc
@@ -17,6 +17,7 @@ RPI_KERNEL_DEVICETREE_OVERLAYS = " \
     overlays/mcp2515-can0-overlay.dtb \
     overlays/mcp2515-can1-overlay.dtb \
     overlays/mcp251xfd-overlay.dtb \
+    overlays/2xMCP2517FD-overlay.dtb \
     overlays/rpi-ft5406-overlay.dtb \
 "
 

--- a/meta-bsp/conf/machine/include/rpi-base.inc
+++ b/meta-bsp/conf/machine/include/rpi-base.inc
@@ -13,8 +13,10 @@ RPI_KERNEL_DEVICETREE_OVERLAYS = " \
     overlays/pitft28-capacitive-overlay.dtb \
     overlays/pitft35-resistive-overlay.dtb \
     overlays/rpi-display-overlay.dtb \
+    overlays/gpio-fan-overlay.dtb \
     overlays/mcp2515-can0-overlay.dtb \
     overlays/mcp2515-can1-overlay.dtb \
+    overlays/mcp251xfd-overlay.dtb \
     overlays/rpi-ft5406-overlay.dtb \
 "
 

--- a/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -20,7 +20,7 @@ B = "${WORKDIR}/build"
 #SRCREV = "6ff6f0c970199071c79176ec6147fda82fb28530"
 #SRC_URI = "git://github.com/victronenergy/linux.git;protocol=git;branch=rpi_4.19.81"
 
-SRCREV = "1375d5eac7a0fd578b49c8dd272425053c322f9c"
+SRCREV = "9793c37f3cc55d9e68ee0eccf9f73c46108f8e09"
 SRC_URI = "git://github.com/nmbath/linux.git;protocol=git;branch=rpi-5.10.y"
 
 # needed for building newer perf

--- a/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -20,7 +20,7 @@ B = "${WORKDIR}/build"
 #SRCREV = "6ff6f0c970199071c79176ec6147fda82fb28530"
 #SRC_URI = "git://github.com/victronenergy/linux.git;protocol=git;branch=rpi_4.19.81"
 
-SRCREV = "6c16243d2dafc5ba413922a8fd45b5eca1ce335c"
+SRCREV = "efa3d4d9283a8c761ee45d1f179ba255c3e69148"
 SRC_URI = "git://github.com/nmbath/linux.git;protocol=git;branch=rpi-5.10.y"
 
 # needed for building newer perf

--- a/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -6,7 +6,7 @@ KBUILD_DEFCONFIG:raspberrypi4 ?= "bcm2711_defconfig"
 
 SECTION = "kernel"
 LICENSE = "GPLv2"
-LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 inherit kernel
 
@@ -17,11 +17,14 @@ KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KBUILD_DEFCONFIG}"
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
 
-SRCREV = "6ff6f0c970199071c79176ec6147fda82fb28530"
-SRC_URI = "git://github.com/victronenergy/linux.git;protocol=git;branch=rpi_4.19.81"
+#SRCREV = "6ff6f0c970199071c79176ec6147fda82fb28530"
+#SRC_URI = "git://github.com/victronenergy/linux.git;protocol=git;branch=rpi_4.19.81"
+
+SRCREV = "1375d5eac7a0fd578b49c8dd272425053c322f9c"
+SRC_URI = "git://github.com/nmbath/linux.git;protocol=git;branch=rpi-5.10.y"
 
 # needed for building newer perf
-SRC_URI += "file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch"
+#SRC_URI += "file://0001-perf-Make-perf-able-to-build-with-latest-libbfd.patch"
 
 # fix make[3]: *** [scripts/extract-cert] Error 1
 DEPENDS += "openssl-native"

--- a/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-raspberrypi_5.10.bb
@@ -20,7 +20,7 @@ B = "${WORKDIR}/build"
 #SRCREV = "6ff6f0c970199071c79176ec6147fda82fb28530"
 #SRC_URI = "git://github.com/victronenergy/linux.git;protocol=git;branch=rpi_4.19.81"
 
-SRCREV = "9793c37f3cc55d9e68ee0eccf9f73c46108f8e09"
+SRCREV = "6c16243d2dafc5ba413922a8fd45b5eca1ce335c"
 SRC_URI = "git://github.com/nmbath/linux.git;protocol=git;branch=rpi-5.10.y"
 
 # needed for building newer perf


### PR DESCRIPTION
Updated to support pulling a test RPI 5.10.y kernel, latest stable boot files and Waveshare Dual channel MCP251xFD can HAT