### PR TITLE
Head patch add rpi 3 a plus

### DIFF
--- a/meta-bsp/conf/machine/raspberrypi2.conf
+++ b/meta-bsp/conf/machine/raspberrypi2.conf
@@ -19,6 +19,7 @@ RPI_KERNEL_DEVICETREE_DTB = " \
     bcm2710-rpi-3-b.dtb \
     bcm2710-rpi-3-b-plus.dtb \
     bcm2710-rpi-zero-2-w.dtb \
+    bcm2837-rpi-3-a-plus.dts \
 "
 
 RPI_KERNEL_DEVICETREE_OVERLAYS += " \

--- a/meta-bsp/conf/machine/raspberrypi2.conf
+++ b/meta-bsp/conf/machine/raspberrypi2.conf
@@ -19,7 +19,7 @@ RPI_KERNEL_DEVICETREE_DTB = " \
     bcm2710-rpi-3-b.dtb \
     bcm2710-rpi-3-b-plus.dtb \
     bcm2710-rpi-zero-2-w.dtb \
-    bcm2837-rpi-3-a-plus.dts \
+    bcm2837-rpi-3-a-plus.dtb \
 "
 
 RPI_KERNEL_DEVICETREE_OVERLAYS += " \

--- a/meta-bsp/recipes-bsp/machine-runtime-conf/files/raspberrypi2/get-unique-id
+++ b/meta-bsp/recipes-bsp/machine-runtime-conf/files/raspberrypi2/get-unique-id
@@ -9,7 +9,7 @@
 # interface, that should _not_ change the unique-id.
 
 case $(board-compat) in
-    raspberrypi,model-zero-w | raspberrypi,model-zero-2-w)
+    raspberrypi,model-zero-w | raspberrypi,model-zero-2-w | raspberrypi,3-model-a-plus)
          if="wlan0"
          ;;
     *)


### PR DESCRIPTION
I've asked here to add support to the Raspberry 3 A+ https://github.com/victronenergy/venus/issues/1113

IMHO those two changes should do the trick and would make people in here happy.
https://community.victronenergy.com/questions/82449/possible-to-install-venus-os-on-raspberry-pi-3-a.html
https://community.victronenergy.com/questions/79169/raspberry-pi-3a-vrm-id-missing.html