### PR TITLE
Add more `pts` entries to securetty

### DIFF
--- a/meta-venus/recipes-extended/shadow/files/securetty-add-serial-ports.patch
+++ b/meta-venus/recipes-extended/shadow/files/securetty-add-serial-ports.patch
@@ -11,3 +11,16 @@
  
  # ARM AMBA SoCs
  ttyAM0
+@@ -151,6 +155,12 @@
+ pts/1
+ pts/2
+ pts/3
++pts/4
++pts/5
++pts/6
++pts/7
++pts/8
++pts/9
+
+ # Embedded Freescale i.MX ports
+ ttymxc0


### PR DESCRIPTION
As described in [the forum](https://community.victronenergy.com/questions/252085/illegal-root-login-and-available-ttys-for-ssh.html) it is easy to run out of the `/dev/pty/*` entries that are used by SSH.

This affects the connectivity of both plain ssh logins and the ssh tunnel that is used for VRM / VictronConnect, and was quite hard to debug (for me at least).