### PR TITLE
Prevent mixing can interfaces (wrong) numbering when usb to can inter…

### DIFF
--- a/meta-venus/recipes-core/udev/files/einstein/machine.rules
+++ b/meta-venus/recipes-core/udev/files/einstein/machine.rules
@@ -3,7 +3,7 @@ ENV{BASE_COMPATIBLE}!="victronenergy,cerbo-gx|victronenergy,cerbo-gx-s", GOTO="e
 ACTION=="add", KERNEL=="ttyS4", ENV{VE_PRODUCT}="builtin-mkx", ENV{VE_SERVICE}="mkx"
 ACTION=="add", KERNEL=="ttyS[5-7]", ENV{VE_PRODUCT}="builtin-vedirect", ENV{VE_SERVICE}="vedirect"
 ACTION=="add", SUBSYSTEM=="iio", ATTR{name}=="cerbo-gx-adc", SYMLINK+="adc/builtin0"
-ACTION=="add", SUBSYSTEM=="net", KERNEL=="can0", ENV{VE_NAME}="VE.Can port"
+ACTION=="add", SUBSYSTEM=="net", ATTR{type}=="280", KERNELS=="1c2bc00.can", NAME="can0", ENV{VE_NAME}="VE.Can port"
 ACTION=="change", SUBSYSTEM=="drm", ENV{HOTPLUG}=="1", RUN+="display-hotplug %p HDMI-A-1 i2c-2"
 ACTION=="change", KERNEL=="*.rtc", ENV{LOSC}=="1", RUN+="sunxi-losc-status %s{losc_status}"
 LABEL="end-cerbo-gx"


### PR DESCRIPTION
Currently, udev rule maps can0 based on the kernel interface name. But when you connect an usb to can adapter sometimes this interface gets can0. In this case the real can0 interface will not used and appears as can2. This will break the configuration because VE.can devices are now on can0.

Change the udev rule maps strict the device 1c2bc00.can to can0 and prevents that issue.