### PR TITLE
Sets up an initial flow for node-red, if no flow exists yet

### DIFF
--- a/meta-venus/recipes-extended/node-red-venus/files/node-red-venus.sh
+++ b/meta-venus/recipes-extended/node-red-venus/files/node-red-venus.sh
@@ -37,6 +37,21 @@ EOF
     fi
 }
 
+init_default_flow() {
+    flows="$NODE_RED/flows.json"
+
+    # never overwrite an existing flow file. Note: it will only exists after a user
+    # deployed it.
+    if [ -e "$flows" ]; then
+        return
+    fi
+
+    cat > $flows << EOF
+[{"id":"victron-client-id","type":"victron-client","showValues":true,"contextStore":true,"enablePolling":false}]
+EOF
+
+}
+
 rename_flows() {
     flows="$NODE_RED/flows.json"
 
@@ -112,6 +127,8 @@ fi
 
 move_secret
 rename_flows
+
+init_default_flow
 
 export TZ=$(get_setting /Settings/System/TimeZone)
 


### PR DESCRIPTION
This relates to https://github.com/victronenergy/venus/issues/1506, and should fix the issue that nodes cannot be configured on a fresh system before the first deploy from node-red.

I tested this change locally.

This is not the full solution yet: In node-red, on deploy, I now get a warning about an unused config node. This may have to be fixed form the node-red-contrib-victron package, I am investigating that.

See also this discussion on the node-red forum:
https://discourse.nodered.org/t/creating-a-config-node-on-demand-import-broken/98188/11 ... I tried to resolve this config node creation issue from within node-red-contrib-victron, but so far without a feasable and clean solution.