### PR TITLE
u-boot-venus-rpi5: Disable interrupt

### DIFF
--- a/meta-bsp/recipes-bsp/u-boot/u-boot-venus-rpi5_2025.04.bb
+++ b/meta-bsp/recipes-bsp/u-boot/u-boot-venus-rpi5_2025.04.bb
@@ -26,4 +26,15 @@ inherit pkgconfig
 
 do_configure[cleandirs] = "${B}"
 
+do_configure:append:raspberrypi5() {
+    # Remove any existing CONFIG_BOOTDELAY= lines
+    sed -i '/^CONFIG_BOOTDELAY=/d' "${B}/.config"
+    # Disable U-Boot interrupt timeout to avoid
+    # boot issues without a connected debug UART
+    # This is a known U-Boot issue discussed in:
+    # https://bugzilla.opensuse.org/show_bug.cgi?id=1251192
+    # https://lists.denx.de/pipermail/u-boot/2025-January/576305.html
+    echo "CONFIG_BOOTDELAY=-2" >> ${B}/.config
+}
+
 require ${COREBASE}/meta/recipes-bsp/u-boot/u-boot.inc


### PR DESCRIPTION
Disable U-Boot interrupt timeout to avoid boot issues without a connected debug UART. This is a known U-Boot issue discussed in:

* openSUSE bug tracker: https://bugzilla.opensuse.org/show_bug.cgi?id=1251192

* U-Boot mailing list: https://lists.denx.de/pipermail/u-boot/2025-January/576305.html