### PR TITLE
raspberrypi5/config.txt: Remove enable_uart=1

### DIFF
--- a/meta-bsp/recipes-bsp/bootfiles-raspberrypi/files/raspberrypi5/config.txt
+++ b/meta-bsp/recipes-bsp/bootfiles-raspberrypi/files/raspberrypi5/config.txt
@@ -1,4 +1,3 @@
-enable_uart=1
 kernel=u-boot.bin
 
 [all]


### PR DESCRIPTION
Remove `enable_uart=1` to allow U-Boot to boot successfully without requiring a UART-to-USB dongle connected to the Raspberry Pi 5 dedicated UART port.
